### PR TITLE
Minor settings refinement and fleshed out the readme info a bit.

### DIFF
--- a/gravity-forms-sisyphus.php
+++ b/gravity-forms-sisyphus.php
@@ -92,7 +92,7 @@ class GFSisyphus {
 	    $settings['Form Options']['enable_sisyphus'] = '
 	        <tr>
 	        	<th>Sisyphus <a href="#" onclick="return false;" class="tooltip tooltip_form_animation" tooltip="&lt;h6&gt;Enable Sisyphus Saving&lt;/h6&gt;Check this option to enable saving forms with local storage through the Sisyphus plugin."></a></th>
-	            <td><input type="checkbox" value="1" '.$checked.' name="enable_sisyphus"> <label for="enable_sisyphus">'.__('Enable local saving of forms', 'gravity-forms-sisyphus').'</label></td>
+	            <td><input type="checkbox" value="1" '.$checked.' name="enable_sisyphus" id="enable_sisyphus"> <label for="enable_sisyphus">'.__('Enable local saving of forms', 'gravity-forms-sisyphus').'</label></td>
 	        </tr>';
 
 	    return $settings;

--- a/readme.md
+++ b/readme.md
@@ -3,11 +3,15 @@ Gravity Forms Sisyphus
 
 Version 2.0.1
 
-Allow for saving your form data with local storage using [Sisyphus](http://sisyphus-js.herokuapp.com/).
+Allow for saving & resuming of your form data with the visitor's local storage using [Sisyphus.js](http://sisyphus-js.herokuapp.com/) until the form is submitted.
 
-Persist your form's data in a browser's Local Storage and never loose them on occasional tabs closing, browser crashes and other disasters!
+Persist your form's data in a browser's Local Storage and never loose them on occasional tabs closing, going offline, browser crashes and other disasters!
 
-Thanks to swingline0 for the updates on v2.0. Now works with paged forms.
+Thanks to [swingline0](https://github.com/Swingline0) for the updates on v2.0. Now works with paged forms.
+
+Additional community support & development is welcome via GitHub: [https://github.com/bhays/gravity-forms-sisyphus](https://github.com/bhays/gravity-forms-sisyphus)
+
+This requires Gravity Forms version 1.7 or higher.
 
 ## Requirements
 * WordPress 3.5
@@ -20,6 +24,9 @@ Thanks to swingline0 for the updates on v2.0. Now works with paged forms.
 3. Toggle the Sisyphus checkbox under Form Settings
 
 ## Changelog
+
+### 2.0.1
+* Minor update
 
 ### 2.0
 * Thanks to swingline0 for the updates on v2.0

--- a/readme.txt
+++ b/readme.txt
@@ -8,15 +8,17 @@ Stable tag: 2.0.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
-Save your form data via local storage using Sisyphus.
+Save & resume your form data via the visitor's local storage using Sisyphus.js until the form is submitted.
 
 == Description ==
 
-Allow for saving your form data with local storage using [Sisyphus](http://sisyphus-js.herokuapp.com/).
+Allow for saving & resuming of your form data with the visitor's local storage using [Sisyphus.js](http://sisyphus-js.herokuapp.com/) until the form is submitted.
 
-Persist your form's data in a browser's Local Storage and never loose them on occasional tabs closing, browser crashes and other disasters!
+Persist your form's data in a browser's Local Storage and never loose them on occasional tabs closing, going offline, browser crashes and other disasters!
 
-Thanks to swingline0 for the updates on v2.0. Now works with paged forms.
+Thanks to [swingline0](https://profiles.wordpress.org/swingline0) for the updates on v2.0. Now works with paged forms.
+
+Additional community support & development is welcome via GitHub: [https://github.com/bhays/gravity-forms-sisyphus](https://github.com/bhays/gravity-forms-sisyphus)
 
 This requires Gravity Forms version 1.7 or higher.
 
@@ -33,6 +35,9 @@ This requires Gravity Forms version 1.7 or higher.
 == Screenshots ==
 
 == Changelog ==
+
+### 2.0.1
+* Minor update
 
 ### 2.0
 * Thanks to swingline0 for the updates on v2.0


### PR DESCRIPTION
This makes it so the checkbox on the form settings to enable Sisyphus has the label correctly toggle the checkbox as you'd expect. Also, I updated the readme to reference GitHub to help encourage community support & development (and also made it so the changelog matched the current version number).

I believe this plugin still has a very useful place that no other plugins (that I'm aware of) resolve.

I placed this on a single page form now and found it was still working well. As such, I wanted to make sure it was still given some updates & attention.

Thanks for the great plugin!